### PR TITLE
Update layout.html

### DIFF
--- a/themes/default/layout.html
+++ b/themes/default/layout.html
@@ -13,7 +13,7 @@
 
     <?php if (!empty($metadata->canonicalUrl)): ?>
     <!-- Canonical URL -->
-    <link rel="canonical" href="<?php echo xss($metadata->canonicalUrl); ?>">
+    <link rel="canonical" href="<?php echo $metadata->canonicalUrl; ?>">
     <?php endif; ?>
 
     <!-- Favicons -->


### PR DESCRIPTION
XSS escaping of canonicalURL tag causes validation failure due to encoding of HTML entitities.