### PR TITLE
Update version, reorder admin menu

### DIFF
--- a/themes/admin/layout.html
+++ b/themes/admin/layout.html
@@ -94,12 +94,14 @@
                   <li><a class="dropdown-item" href="<?php echo TFISH_PREFERENCE_URL; ?>"><?php echo TFISH_PREFERENCES; ?></a></li>
                   <li><a class="dropdown-item" href="<?php echo TFISH_URL . 'admin/blocks/'; ?>"><?php echo TFISH_ADMIN_BLOCKS; ?></a></li>
                   <li><a class="dropdown-item" href="<?php echo TFISH_ADMIN_USER_URL; ?>"><?php echo TFISH_USERS; ?></a></li>
-                  <li><a class="dropdown-item" href="<?php echo TFISH_EMAIL_URL; ?>"><?php echo TFISH_PREFERENCE_MAIL_SETTINGS; ?></a></li>
                   <?php endif; ?>
                   <li><a class="dropdown-item" href="<?php echo TFISH_PASSWORD_URL; ?>"><?php echo TFISH_PASSWORD; ?></a></li>
                   <li><a class="dropdown-item" href="<?php echo TFISH_WEBAUTHN_URL; ?>"><?php echo TFISH_TWO_FACTOR_AUTH; ?></a></li>
-                  <li><a class="dropdown-item" href="<?php echo TFISH_URL . 'flush/'; ?>"><?php echo TFISH_FLUSH_CACHE; ?></a></li>
+                  <?php if ($session->isAdmin()): ?>
+                  <li><a class="dropdown-item" href="<?php echo TFISH_EMAIL_URL; ?>"><?php echo TFISH_PREFERENCE_MAIL_SETTINGS; ?></a></li>
                   <li><a class="dropdown-item" href="<?php echo TFISH_URL . 'sitemap/'; ?>"><?php echo TFISH_UPDATE_SITEMAP; ?></a></li>
+                  <li><a class="dropdown-item" href="<?php echo TFISH_URL . 'flush/'; ?>"><?php echo TFISH_FLUSH_CACHE; ?></a></li>
+                  <?php endif; ?>
                 </ul>
               </li>
               <?php endif; ?>

--- a/trust_path/libraries/tuskfish/version.php
+++ b/trust_path/libraries/tuskfish/version.php
@@ -15,6 +15,6 @@ namespace Tfish;
  * @package     core
  */
 
-$version = 'Tuskfish V2.2.7';
-$released = '13 January 2026';
+$version = 'Tuskfish V2.2.8';
+$released = '16 May 2026';
 $minPhpVersion = '8.4';


### PR DESCRIPTION
- **Reorder admin settings menu**
- **Mark as Tuskfish v2.2.8**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Non-admin users no longer see email preferences, sitemap, and cache management options in the settings dropdown.

* **Chores**
  * Updated version to V2.2.8 and release date to 16 May 2026.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crushdepth/tuskfish2/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->