### PR TITLE
Smtp password encryption

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,3 +20,42 @@ disclosed will be publicly credited in patch/commit notes together with
 the notification date.
 
 Thanks.
+
+## SMTP password encryption at rest
+
+The SMTP password is encrypted before it is stored in the database, using
+libsodium (XSalsa20-Poly1305, authenticated). The encryption key is a random
+32-byte value held in `trust_path/configuration/config.php` as the constant
+`TFISH_ENCRYPTION_KEY` — never in the database. This protects the stored
+password if the database alone is disclosed (for example, a leaked backup of
+the database file). It does not protect against compromise of the config file
+itself, since the running application must be able to decrypt.
+
+**New installations:** the key is generated automatically during installation.
+No action is required.
+
+**If the key is absent** (for example, an older site upgraded in place, or if
+you delete the constant), the SMTP password is stored as plain text exactly as
+before. Encryption is therefore opt-in for existing sites and fully reversible.
+
+> **Keep the key safe.** Changing or removing `TFISH_ENCRYPTION_KEY` makes any
+> already-encrypted password undecryptable. The application fails soft (it reads
+> the password as empty rather than erroring); just re-enter the SMTP password
+> in the admin preferences and re-save.
+
+### Enabling encryption on an existing site
+
+`config.php` is normally set to read-only (0400), so this is a one-time manual
+step:
+
+1. Generate a key:
+   `php -r 'echo base64_encode(sodium_crypto_secretbox_keygen()), PHP_EOL;'`
+2. Make the config writable: `chmod 0600 trust_path/configuration/config.php`
+3. Append this line (using your generated key), then save:
+   ```php
+   if (!\defined("TFISH_ENCRYPTION_KEY")) define("TFISH_ENCRYPTION_KEY", "<paste-key>");
+   ```
+4. Restore read-only: `chmod 0400 trust_path/configuration/config.php`
+5. In the admin preferences, re-save the SMTP settings once. This re-stores the
+   existing password in encrypted form (until then it keeps working as plain
+   text). Confirm the stored value now begins with `enc:v1:`.

--- a/install/index.php
+++ b/install/index.php
@@ -147,6 +147,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             \define("TFISH_DATABASE", $dbPath);
         }
 
+        // Generate a random key used to encrypt the SMTP password at rest, and append it to
+        // config.php. Keep this key safe: changing or removing it means re-entering the SMTP
+        // password. If you do not want encryption at rest, delete the constant from config.php.
+        if (!\defined("TFISH_ENCRYPTION_KEY")) {
+            $keyConstant = 'if (!\defined("TFISH_ENCRYPTION_KEY")) define("TFISH_ENCRYPTION_KEY", "'
+                    . \Tfish\Crypto::newKeyBase64() . '");';
+            $fileHandler->appendToFile(TFISH_CONFIGURATION_PATH, $keyConstant);
+        }
+
         $sql = "CREATE TABLE IF NOT EXISTS `user` (
             `id` INTEGER PRIMARY KEY,
             `adminEmail` TEXT NOT NULL UNIQUE,

--- a/trust_path/libraries/tuskfish/class/Tests/CryptoTest.php
+++ b/trust_path/libraries/tuskfish/class/Tests/CryptoTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+/**
+ * \Tests\CryptoTest class file.
+ *
+ * @copyright   Simon Wilkinson 2024+ (https://tuskfish.biz)
+ * @license     https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html GNU General Public License (GPL) V2
+ * @author      Simon Wilkinson <simon@isengard.biz>
+ * @version     Release: 2.0
+ * @since       2.0
+ * @package     tests
+ */
+
+ /**
+ * Unit tests for the Crypto encryption helper.
+ *
+ * @copyright   Simon Wilkinson 2024+ (https://tuskfish.biz)
+ * @license     https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html GNU General Public License (GPL) V2
+ * @author      Simon Wilkinson <simon@isengard.biz>
+ * @version     Release: 2.0
+ * @since       2.0
+ * @package     core
+ * @uses        class \Tfish\Crypto
+ */
+
+use PHPUnit\Framework\TestCase;
+use Tfish\Crypto;
+
+class CryptoTest extends TestCase
+{
+    private string $key;
+
+    protected function setUp(): void
+    {
+        $this->key = Crypto::newKeyBase64();
+    }
+
+    public function testNewKeyIsThirtyTwoBytes(): void
+    {
+        $raw = \base64_decode(Crypto::newKeyBase64(), true);
+        $this->assertNotFalse($raw);
+        $this->assertSame(SODIUM_CRYPTO_SECRETBOX_KEYBYTES, \strlen($raw));
+    }
+
+    public function testRoundTrip(): void
+    {
+        $secret = 'hunter2-correct-horse';
+        $cipher = Crypto::encrypt($secret, $this->key);
+
+        $this->assertStringStartsWith('enc:v1:', $cipher);
+        $this->assertNotSame($secret, $cipher);
+        $this->assertSame($secret, Crypto::decrypt($cipher, $this->key));
+    }
+
+    public function testEncryptionIsNonDeterministic(): void
+    {
+        // A fresh nonce each call means identical input yields different ciphertext.
+        $a = Crypto::encrypt('same', $this->key);
+        $b = Crypto::encrypt('same', $this->key);
+        $this->assertNotSame($a, $b);
+        $this->assertSame('same', Crypto::decrypt($a, $this->key));
+        $this->assertSame('same', Crypto::decrypt($b, $this->key));
+    }
+
+    public function testEmptyStringIsNotEncrypted(): void
+    {
+        $this->assertSame('', Crypto::encrypt('', $this->key));
+        $this->assertSame('', Crypto::decrypt('', $this->key));
+    }
+
+    public function testEncryptWithoutKeyReturnsPlaintext(): void
+    {
+        // No key available => legacy plaintext storage.
+        $this->assertSame('secret', Crypto::encrypt('secret', ''));
+    }
+
+    public function testLegacyPlaintextPassesThroughDecrypt(): void
+    {
+        // A value with no enc:v1: prefix is treated as legacy plaintext.
+        $this->assertSame('plain-old-password', Crypto::decrypt('plain-old-password', $this->key));
+    }
+
+    public function testTaggedValueWithWrongKeyFailsSoft(): void
+    {
+        $cipher = Crypto::encrypt('secret', $this->key);
+        $otherKey = Crypto::newKeyBase64();
+        $this->assertSame('', Crypto::decrypt($cipher, $otherKey));
+    }
+
+    public function testTaggedValueWithNoKeyFailsSoft(): void
+    {
+        $cipher = Crypto::encrypt('secret', $this->key);
+        $this->assertSame('', Crypto::decrypt($cipher, ''));
+    }
+
+    public function testTamperedCiphertextFailsSoft(): void
+    {
+        $cipher = Crypto::encrypt('secret', $this->key);
+        // Flip the final character of the base64 payload.
+        $tampered = \substr($cipher, 0, -1) . ($cipher[-1] === 'A' ? 'B' : 'A');
+        $this->assertSame('', Crypto::decrypt($tampered, $this->key));
+    }
+
+    public function testMalformedKeyFailsSoft(): void
+    {
+        $cipher = Crypto::encrypt('secret', $this->key);
+        $this->assertSame('', Crypto::decrypt($cipher, 'not-a-valid-key'));
+        // Too-short key cannot encrypt either, so plaintext is returned.
+        $this->assertSame('secret', Crypto::encrypt('secret', 'short'));
+    }
+}

--- a/trust_path/libraries/tuskfish/class/Tfish/Crypto.php
+++ b/trust_path/libraries/tuskfish/class/Tfish/Crypto.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tfish;
+
+/**
+ * \Tfish\Crypto class file.
+ *
+ * @copyright   Simon Wilkinson 2013+ (https://tuskfish.biz)
+ * @license     https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html GNU General Public License (GPL) V2
+ * @author      Simon Wilkinson <simon@isengard.biz>
+ * @version     Release: 2.0
+ * @since       2.0
+ * @package     core
+ */
+
+/**
+ * Authenticated symmetric encryption for secrets stored at rest (eg. the SMTP password).
+ *
+ * Uses libsodium's secretbox (XSalsa20-Poly1305), which is built into PHP and authenticated, so
+ * tampering with the ciphertext is detected. The key is a random 32-byte value written to
+ * config.php as the constant TFISH_ENCRYPTION_KEY during installation. Because the key lives in
+ * config.php (outside the web root, and not in the database), this protects a stored secret if the
+ * database alone is disclosed; it does not protect against compromise of the config file itself.
+ *
+ * Stored ciphertext is tagged with a version prefix (enc:v1:) so reads can distinguish encrypted
+ * values from legacy plaintext, and degrade safely if the key is absent or changed.
+ *
+ * Behaviour is deliberately permissive at the edges so the feature is opt-in and reversible:
+ * - With no key available, encrypt() returns the plaintext unchanged (legacy plaintext storage).
+ * - An empty string is never encrypted (keeps empty-password checks working).
+ * - decrypt() returns plaintext unchanged when there is no enc:v1: prefix (legacy value), and
+ *   returns an empty string if a tagged value cannot be decrypted (missing/changed key, or
+ *   tampering) so callers fail soft rather than fatal.
+ *
+ * @copyright   Simon Wilkinson 2013+ (https://tuskfish.biz)
+ * @license     https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html GNU General Public License (GPL) V2
+ * @author      Simon Wilkinson <simon@isengard.biz>
+ * @version     Release: 2.0
+ * @since       2.0
+ * @package     core
+ */
+class Crypto
+{
+    /** Marker prepended to encrypted values to identify them and allow versioning. */
+    private const PREFIX = 'enc:v1:';
+
+    /**
+     * Generate a new random encryption key, base64 encoded for storage in config.php.
+     *
+     * @return string Base64 encoded 32-byte key.
+     */
+    public static function newKeyBase64(): string
+    {
+        return \base64_encode(\sodium_crypto_secretbox_keygen());
+    }
+
+    /**
+     * Encrypt a secret for storage.
+     *
+     * Returns the input unchanged if it is empty or if no key is available (so installs without a
+     * key continue to store plaintext). Otherwise returns a self-describing enc:v1: token.
+     *
+     * @param string $plaintext The value to encrypt.
+     * @param string|null $keyBase64 Optional base64 key (defaults to the TFISH_ENCRYPTION_KEY constant).
+     * @return string Encrypted enc:v1: token, or the original value when not encrypting.
+     */
+    public static function encrypt(string $plaintext, ?string $keyBase64 = null): string
+    {
+        if ($plaintext === '') {
+            return $plaintext;
+        }
+
+        $key = self::resolveKey($keyBase64);
+
+        if ($key === null) {
+            return $plaintext;
+        }
+
+        $nonce = \random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $cipher = \sodium_crypto_secretbox($plaintext, $nonce, $key);
+
+        return self::PREFIX . \base64_encode($nonce . $cipher);
+    }
+
+    /**
+     * Decrypt a stored secret.
+     *
+     * A value without the enc:v1: prefix is treated as legacy plaintext and returned unchanged. A
+     * tagged value that cannot be decrypted (no/changed key, corruption or tampering) returns an
+     * empty string so the caller fails soft.
+     *
+     * @param string $stored The stored value.
+     * @param string|null $keyBase64 Optional base64 key (defaults to the TFISH_ENCRYPTION_KEY constant).
+     * @return string The decrypted plaintext, the original value (legacy plaintext), or ''.
+     */
+    public static function decrypt(string $stored, ?string $keyBase64 = null): string
+    {
+        if (\strncmp($stored, self::PREFIX, \strlen(self::PREFIX)) !== 0) {
+            return $stored;
+        }
+
+        $key = self::resolveKey($keyBase64);
+
+        if ($key === null) {
+            return '';
+        }
+
+        $decoded = \base64_decode(\substr($stored, \strlen(self::PREFIX)), true);
+
+        if ($decoded === false || \strlen($decoded) <= SODIUM_CRYPTO_SECRETBOX_NONCEBYTES) {
+            return '';
+        }
+
+        $nonce = \substr($decoded, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $cipher = \substr($decoded, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+
+        try {
+            $plaintext = \sodium_crypto_secretbox_open($cipher, $nonce, $key);
+        } catch (\SodiumException $e) {
+            return '';
+        }
+
+        return $plaintext === false ? '' : $plaintext;
+    }
+
+    /**
+     * Resolve and validate the raw binary key from an explicit value or the config constant.
+     *
+     * @param string|null $keyBase64 Explicit base64 key, or null to use TFISH_ENCRYPTION_KEY.
+     * @return string|null 32-byte binary key, or null if unavailable/malformed.
+     */
+    private static function resolveKey(?string $keyBase64): ?string
+    {
+        if ($keyBase64 === null) {
+            if (!\defined('TFISH_ENCRYPTION_KEY')) {
+                return null;
+            }
+
+            $keyBase64 = (string) \constant('TFISH_ENCRYPTION_KEY');
+        }
+
+        $key = \base64_decode($keyBase64, true);
+
+        if ($key === false || \strlen($key) !== SODIUM_CRYPTO_SECRETBOX_KEYBYTES) {
+            return null;
+        }
+
+        return $key;
+    }
+}

--- a/trust_path/libraries/tuskfish/class/Tfish/Entity/Preference.php
+++ b/trust_path/libraries/tuskfish/class/Tfish/Entity/Preference.php
@@ -180,6 +180,11 @@ class Preference
             $preferences[$row['title']] = $row['value'];
         }
 
+        // Decrypt the SMTP password (if stored encrypted) so the entity holds plaintext in memory.
+        if (isset($preferences['smtpPassword'])) {
+            $preferences['smtpPassword'] = \Tfish\Crypto::decrypt($preferences['smtpPassword']);
+        }
+
         return $preferences;
     }
 

--- a/trust_path/libraries/tuskfish/class/Tfish/Entity/Preference.php
+++ b/trust_path/libraries/tuskfish/class/Tfish/Entity/Preference.php
@@ -121,6 +121,9 @@ class Preference
 
         unset($preferences['database']);
 
+        // Encrypt the SMTP password for storage (no-op if no key is configured).
+        $preferences['smtpPassword'] = $this->smtpPasswordForStorage();
+
         return $preferences;
     }
 
@@ -888,6 +891,20 @@ class Preference
     public function smtpPassword(): string
     {
         return $this->smtpPassword;
+    }
+
+    /**
+     * The SMTP password in its at-rest (encrypted) form, for writing to the database.
+     *
+     * Paired with the decryption in readPreferences(): the entity holds plaintext in memory and
+     * exposes the encrypted form only when persisting. Returns plaintext unchanged if no encryption
+     * key is configured. See \Tfish\Crypto.
+     *
+     * @return string Encrypted SMTP password (enc:v1: token), or plaintext if no key is set.
+     */
+    public function smtpPasswordForStorage(): string
+    {
+        return \Tfish\Crypto::encrypt($this->smtpPassword);
     }
 
     public function setSmtpPassword(string $value): void

--- a/trust_path/libraries/tuskfish/class/Tfish/Model/Email.php
+++ b/trust_path/libraries/tuskfish/class/Tfish/Model/Email.php
@@ -56,6 +56,12 @@ class Email
         $existingKeys = $this->existingPreferenceKeys();
 
         foreach ($smtpKeys as $key => $value) {
+            // Encrypt the SMTP password at the storage boundary (no-op if no key is configured).
+            // NB: Model\Preference::writePreferences() does the same; keep both in sync.
+            if ($key === 'smtpPassword') {
+                $value = \Tfish\Crypto::encrypt((string) $value);
+            }
+
             if (\in_array($key, $existingKeys, true)) {
                 $sql = "UPDATE `preference` SET `value` = :value WHERE `title` = :title";
             } else {

--- a/trust_path/libraries/tuskfish/class/Tfish/Model/Email.php
+++ b/trust_path/libraries/tuskfish/class/Tfish/Model/Email.php
@@ -50,18 +50,12 @@ class Email
             'smtpPort' => (string) $this->preference->smtpPort(),
             'smtpEncryption' => (string) $this->preference->smtpEncryption(),
             'smtpUser' => (string) $this->preference->smtpUser(),
-            'smtpPassword' => (string) $this->preference->smtpPassword(),
+            'smtpPassword' => $this->preference->smtpPasswordForStorage(),
         ];
 
         $existingKeys = $this->existingPreferenceKeys();
 
         foreach ($smtpKeys as $key => $value) {
-            // Encrypt the SMTP password at the storage boundary (no-op if no key is configured).
-            // NB: Model\Preference::writePreferences() does the same; keep both in sync.
-            if ($key === 'smtpPassword') {
-                $value = \Tfish\Crypto::encrypt((string) $value);
-            }
-
             if (\in_array($key, $existingKeys, true)) {
                 $sql = "UPDATE `preference` SET `value` = :value WHERE `title` = :title";
             } else {

--- a/trust_path/libraries/tuskfish/class/Tfish/Model/Preference.php
+++ b/trust_path/libraries/tuskfish/class/Tfish/Model/Preference.php
@@ -101,6 +101,11 @@ class Preference
         $existingKeys = $this->existingPreferenceKeys();
 
         foreach ($keyValues as $key => $value) {
+            // Encrypt the SMTP password at the storage boundary (no-op if no key is configured).
+            if ($key === 'smtpPassword') {
+                $value = \Tfish\Crypto::encrypt((string) $value);
+            }
+
             if (\in_array($key, $existingKeys, true)) {
                 $sql = "UPDATE `preference` SET `value` = :value WHERE `title` = :title";
             } else {

--- a/trust_path/libraries/tuskfish/class/Tfish/Model/Preference.php
+++ b/trust_path/libraries/tuskfish/class/Tfish/Model/Preference.php
@@ -101,12 +101,6 @@ class Preference
         $existingKeys = $this->existingPreferenceKeys();
 
         foreach ($keyValues as $key => $value) {
-            // Encrypt the SMTP password at the storage boundary (no-op if no key is configured).
-            // NB: Model\Email::writeSmtpPreferences() does the same; keep both in sync.
-            if ($key === 'smtpPassword') {
-                $value = \Tfish\Crypto::encrypt((string) $value);
-            }
-
             if (\in_array($key, $existingKeys, true)) {
                 $sql = "UPDATE `preference` SET `value` = :value WHERE `title` = :title";
             } else {

--- a/trust_path/libraries/tuskfish/class/Tfish/Model/Preference.php
+++ b/trust_path/libraries/tuskfish/class/Tfish/Model/Preference.php
@@ -102,6 +102,7 @@ class Preference
 
         foreach ($keyValues as $key => $value) {
             // Encrypt the SMTP password at the storage boundary (no-op if no key is configured).
+            // NB: Model\Email::writeSmtpPreferences() does the same; keep both in sync.
             if ($key === 'smtpPassword') {
                 $value = \Tfish\Crypto::encrypt((string) $value);
             }


### PR DESCRIPTION
Encrypt SMTP passwords at rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SMTP passwords are now encrypted at rest by default on new installations.
  * Automatic encryption key generation and configuration during setup.
  * Post-upgrade encryption guidance for existing sites.

* **Documentation**
  * Updated security policy documenting password encryption implementation and operational instructions.

* **Tests**
  * Added comprehensive test coverage for encryption functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->